### PR TITLE
Pull request template

### DIFF
--- a/.github/workflows/PULL_REQUEST_TEMPLATE.md
+++ b/.github/workflows/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+This PR fixes #issue_number _(If you are fixing a bug)_ which reported a bug that caused a problem to occur when users...
+
+_(or if you are introducing a new feature)_ which requested a feature to allow the user to...
+
+
+## Description
+<!--- Describe your changes in detail -->
+
+## How has this been tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, tests ran to see how -->
+<!--- your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):
+
+## Still to do:
+
+<!--
+If this is a work-in-progress (WIP), list the changes you still need to make and/or questions or the reviewer(s). You can also mention extensions to your work that might be added as an issue to work on after the PR.
+-->
+
+- [ ]
+- [ ]
+- [ ]
+
+## Questions for the reviewer(s):
+
+- [ ]
+- [ ]


### PR DESCRIPTION
This PR introduces a pull request template that will make it easier and more standardized to provide descriptive text to reviewers when a PR is opened.

## Description
This PR adds a single file to the .github directory which Github will use to create a template when users click the "open pull request" button.

## How has this been tested?
We have a similar template for the [yellowbrick project](https://github.com/DistrictDataLabs/yellowbrick/blob/develop/.github/PULL_REQUEST_TEMPLATE.md)

## Screenshots (if appropriate):
![Screen Shot 2021-09-20 at 11 21 27 AM](https://user-images.githubusercontent.com/8760385/134028306-57250e9b-1964-42bf-9ad5-da222020662d.png)


## Still to do:
N/A

## Questions for the reviewer(s):
 
@KNGJOEL &mdash; I've removed some of the fields from the example you sent initially to simplify the template slightly. Let me know if this feels helpful!
