### PR TITLE
shortcode to avoid unsafe=true

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -65,4 +65,4 @@ weight = 10
 [markup]
 [markup.goldmark]
 [markup.goldmark.renderer]
-unsafe = true
+unsafe = false

--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -10,16 +10,5 @@ If you'd like to get in touch with us, please feel free to open an issue on GitH
 
 Special thanks to [Eucalyp](https://thenounproject.com/eucalyp/) from [The Noun Project](https://thenounproject.com/) who created the logo we're currently using.
 
-<!--Rotating globe-->
-<div id="observablehq-canvas-1372f32a"></div>
-
-<script type="module">
-import {Runtime, Inspector} from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js";
-import define from "https://api.observablehq.com/@kngjoel/untitled.js?v=3";
-new Runtime().module(define, name => {
-  if (name === "canvas") return new Inspector(document.querySelector("#observablehq-canvas-1372f32a"));
-});
-</script>
-<!--End of Rotating globe-->
-
-<p align="center">Thanks to <a href="https://observablehq.com/@mbostock">Mike Bostock</a> for the world tour animation, originally from <a href="https://observablehq.com">Observable</a> </p>
+{{< worldtour >}}
+{{< worldtourthanks >}}

--- a/content/_index.fr.md
+++ b/content/_index.fr.md
@@ -10,16 +10,5 @@ Si vous souhaitez nous contacter, n'hésitez pas à ouvrir un issue sur GitHub o
 
 Grand merci à [Eucalyp](https://thenounproject.com/eucalyp/) de [The Noun Project](https://thenounproject.com/) qui a créé ce logo.
 
-<!--Rotating globe-->
-<div id="observablehq-canvas-1372f32a"></div>
-
-<script type="module">
-import {Runtime, Inspector} from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js";
-import define from "https://api.observablehq.com/@kngjoel/untitled.js?v=3";
-new Runtime().module(define, name => {
-  if (name === "canvas") return new Inspector(document.querySelector("#observablehq-canvas-1372f32a"));
-});
-</script>
-<!--End of Rotating globe-->
-
-<p align="center">Très reconnaissant pour l'animation world tour de <a href="https://observablehq.com/@mbostock">Mike Bostock</a> d'<a href="https://observablehq.com">Observable</a> </p>
+{{< worldtour >}}
+{{< worldtourthanksfr >}}

--- a/layouts/shortcodes/worldtour.html
+++ b/layouts/shortcodes/worldtour.html
@@ -1,0 +1,9 @@
+<div id="observablehq-canvas-1372f32a"></div>
+
+<script type="module">
+import {Runtime, Inspector} from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js";
+import define from "https://api.observablehq.com/@kngjoel/untitled.js?v=3";
+new Runtime().module(define, name => {
+  if (name === "canvas") return new Inspector(document.querySelector("#observablehq-canvas-1372f32a"));
+});
+</script>

--- a/layouts/shortcodes/worldtourthanks.html
+++ b/layouts/shortcodes/worldtourthanks.html
@@ -1,0 +1,1 @@
+<p align="center">Thanks to <a href="https://observablehq.com/@mbostock">Mike Bostock</a> for the world tour animation, originally from <a href="https://observablehq.com">Observable</a> </p>

--- a/layouts/shortcodes/worldtourthanksfr.html
+++ b/layouts/shortcodes/worldtourthanksfr.html
@@ -1,0 +1,1 @@
+<p align="center">Très reconnaissant pour l'animation world tour de <a href="https://observablehq.com/@mbostock">Mike Bostock</a> d'<a href="https://observablehq.com">Observable</a> </p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes permit to avoid `unsafe=true` to show the rotating globe on the homepage and by the way introduce the use of shortcodes as solution
## Description
<!--- Describe your changes in detail -->
Puted `unsafe=true` to `unsafe=false`
Removed rotating globe's script from both english and french homepage
Created shortcodes folder:  /layouts/shortcodes
Created Shortcodes for Rotating globe and both english and french special thanks 
