### PR TITLE
Adds anti entropy presentation

### DIFF
--- a/content/topics/anti_entropy/_index.en.md
+++ b/content/topics/anti_entropy/_index.en.md
@@ -1,0 +1,10 @@
+---
+title: "How Does Anti-Entropy Work?"
+date: Fri Jan 21 17:27:18 EST 2022
+description: "A Step-by-Step Guide to Bilateral Anti-Entropy Replication"
+anchor: "antientropy"
+weight: 26
+---
+
+
+{{< gslides src="https://docs.google.com/presentation/d/e/2PACX-1vSbcPtPzZ_gmBCX7dAZCjNEAzANl_MQ2dqTDWBzLGgE1SalPbJl4ckE1C1BnRDDOi3JaHkhZKzVI_7b/embed?start=true&loop=true&delayms=3000" >}}

--- a/themes/learn/layouts/shortcodes/gslides.html
+++ b/themes/learn/layouts/shortcodes/gslides.html
@@ -1,0 +1,8 @@
+<div id="Container"
+ style="padding-bottom:56.25%; position:relative; display:block; width: 100%">
+ <iframe id="googleSlideIframe"
+  width="100%" height="100%"
+  src="{{ .Get "src" }}"
+  frameborder="0" allowfullscreen=""
+  style="position:absolute; top:0; left: 0"></iframe>
+</div>


### PR DESCRIPTION
This PR resolves sc-2696 by adding an instructional slide deck about bilateral anti-entropy to the geodistributed.systems website. The slide deck is [here](https://docs.google.com/presentation/d/1HhP5PwV5vyqU93SQsLx3IwD_5t-vPZFxYF8kTIiMfEc/edit?usp=sharing) and the original image files are also in Drive, so they should be fairly easy to edit/repurpose.